### PR TITLE
Version 1.0.2 (longer session age and Django update)

### DIFF
--- a/bird_identification_web/bird_identification_web/settings_dist.py
+++ b/bird_identification_web/bird_identification_web/settings_dist.py
@@ -172,6 +172,10 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 
+# Long session cookie age
+SESSION_COOKIE_AGE = 2*365*24*60*60 # 10 years
+
+
 # Custom variables
 
 STREAM_INTERFACE_PATH = os.environ.get("STREAM_INTERFACE_PATH", "/stream_interface/stream")

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,4 +1,4 @@
-Django==5.1.5
+Django==5.1.7
 mod-wsgi==5.0.2
 djangorestframework==3.15.2
 python-dateutil==2.9.0.post0


### PR DESCRIPTION
Changelog:
 - set the `SESSION_COOKIE_AGE` setting to 2 years
 - updated Django to version 5.1.7

EDIT: Changed the `SESSION_COOKIE_AGE` description to what it was really set.