### PR TITLE
Fix: Version 1.0.2 (longer session age and Django update)

### DIFF
--- a/bird_identification_web/bird_identification_web/settings_dist.py
+++ b/bird_identification_web/bird_identification_web/settings_dist.py
@@ -173,7 +173,7 @@ AUTHENTICATION_BACKENDS = [
 
 
 # Long session cookie age
-SESSION_COOKIE_AGE = 2*365*24*60*60 # 10 years
+SESSION_COOKIE_AGE = 10*365*24*60*60 # 10 years
 
 
 # Custom variables


### PR DESCRIPTION
This is a fix of #7 in which the real session cookie age was 2 years instead of 10.